### PR TITLE
Stuck robot fix

### DIFF
--- a/Assets/Prefabs/DoraRobot2D.prefab
+++ b/Assets/Prefabs/DoraRobot2D.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   leftWheelTransform: {fileID: 3562388383311551113}
   rightWheelTransform: {fileID: 5898286729133033185}
+  id: -1
 --- !u!1001 &9210634985911898445
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MapGeneration/RobotSpawner.cs
+++ b/Assets/Scripts/MapGeneration/RobotSpawner.cs
@@ -188,9 +188,11 @@ namespace Dora.MapGeneration
             if (0.001f > relativeSize && relativeSize > 1.0000001f)
                 throw new ArgumentException(
                     "Robot relative size cannot exceed 1.0f or be below 0.001f. Otherwise some areas of the map may be impossible to explore");
-            robot.transform.localScale = new Vector3(0.495f * relativeSize * collisionMap.Scale,
+            robot.transform.localScale = new Vector3(
                 0.495f * relativeSize * collisionMap.Scale,
-                0.495f * relativeSize * collisionMap.Scale);
+                0.495f * relativeSize * collisionMap.Scale,
+                0.495f * relativeSize * collisionMap.Scale
+                );
 
             float RTOffset = 0.01f; // Offset is used, since being exactly at integer value positions can cause issues with ray tracing
             robot.transform.position = new Vector3((x * collisionMap.Scale) + RTOffset + collisionMap.ScaledOffset.x, (y * collisionMap.Scale) + RTOffset + collisionMap.ScaledOffset.y);

--- a/Assets/Scripts/Robot/MonaRobot.cs
+++ b/Assets/Scripts/Robot/MonaRobot.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Dora.ExplorationAlgorithm;
+using UnityEditor.UI;
 using UnityEngine;
 
 namespace Dora.Robot
@@ -18,14 +20,15 @@ namespace Dora.Robot
         // The algorithm that controls the logic of the robot
         public IExplorationAlgorithm ExplorationAlgorithm { get; set; }
 
+        public List<GameObject> _collidingGameObjects = new List<GameObject>();
+
         private void Awake()
         {
             var rigidBody = GetComponent<Rigidbody2D>();
             movementController = new Robot2DController(rigidBody, transform, leftWheelTransform, rightWheelTransform, this);
         }
 
-        public void LogicUpdate()
-        {
+        public void LogicUpdate() {
             ExplorationAlgorithm.UpdateLogic();
             movementController.UpdateLogic();
         }
@@ -37,13 +40,18 @@ namespace Dora.Robot
 
         private void OnCollisionEnter2D(Collision2D other)
         {
+            if (!_collidingGameObjects.Contains(other.gameObject))
+                _collidingGameObjects.Add(other.gameObject);
+            
             movementController.NotifyCollided();
         }
 
         private void OnCollisionExit2D(Collision2D other)
         {
-            // TODO? Check that all collisions have exited before calling collision exit on controller
-            movementController.NotifyCollisionExit();
+            _collidingGameObjects.Remove(other.gameObject);
+            
+            if (_collidingGameObjects.Count == 0)
+                movementController.NotifyCollisionExit();
         }
 
         public object SaveState()

--- a/Assets/Scripts/Robot/Robot2DController.cs
+++ b/Assets/Scripts/Robot/Robot2DController.cs
@@ -53,9 +53,7 @@ namespace Dora
             _rightWheel = rightWheel;
             _robot = robot;
         }
-
         
-
         public void UpdateLogic()
         {
             // Clear the collision flag

--- a/Assets/Scripts/ScenarioGenerator.cs
+++ b/Assets/Scripts/ScenarioGenerator.cs
@@ -11,10 +11,11 @@ namespace Dora
             
             for (int i = 0; i < 5; i++)
             {
-                int randomSeed = i + 4;
+                int randomSeed = i + 4 + 1;
+                int minute = 60;
                 var mapConfig = new CaveMapConfig(
-                    60,
-                    60,
+                    80,
+                    80,
                     randomSeed,
                     4,
                     2,
@@ -25,8 +26,8 @@ namespace Dora
                     1f);
 
                 var officeConfig = new OfficeMapConfig(
-                    60,
-                    60,
+                    80,
+                    80,
                     randomSeed, 
                     58,
                     4,
@@ -41,14 +42,36 @@ namespace Dora
                     broadcastRange: 15.0f,
                     broadcastBlockedByWalls: true
                 );
+
+                if (i % 2 == 0) {
+                    scenarios.Enqueue(new SimulationScenario(
+                        seed: randomSeed,
+                        hasFinishedSim: (simulation) => simulation.SimulateTimeSeconds >= 20 * minute,
+                        mapSpawner: (mapGenerator) => mapGenerator.GenerateOfficeMap(officeConfig, 2.0f),
+                        robotSpawner: (map, robotSpawner) => robotSpawner.SpawnRobotsTogether(
+                            map, 
+                            randomSeed, 
+                            30, 
+                            0.6f,
+                            new Coord(20,20)),
+                        robotConstraints: robotConstraints
+                    ));
+                }
+                else {
+                    scenarios.Enqueue(new SimulationScenario(
+                        seed: randomSeed,
+                        hasFinishedSim: (simulation) => simulation.SimulateTimeSeconds >= 20 * minute,
+                        mapSpawner: (mapGenerator) => mapGenerator.GenerateCaveMap(mapConfig, 2.0f),
+                        robotSpawner: (map, robotSpawner) => robotSpawner.SpawnRobotsTogether(
+                            map, 
+                            randomSeed, 
+                            30, 
+                            0.6f,
+                            new Coord(20,20)),
+                        robotConstraints: robotConstraints
+                    )); 
+                }
                 
-                scenarios.Enqueue(new SimulationScenario(
-                    seed: randomSeed,
-                    hasFinishedSim: (simulation) => simulation.SimulateTimeSeconds >= 300,
-                    mapSpawner: (mapGenerator) => mapGenerator.GenerateCaveMap(mapConfig, 4.0f),
-                    robotSpawner: (map, robotSpawner) => robotSpawner.SpawnRobotsTogether(map, randomSeed, 10, 0.6f,new Coord(20,20)),
-                    robotConstraints
-                ));
             }
 
             return scenarios;


### PR DESCRIPTION
The robots now keep track of colliding objects in order to only call the exited collisions function, when all colliding objects have been exited. 