### PR TITLE
Hotfix for camera null reference exception

### DIFF
--- a/Assets/Scenes/SimulationScene.unity
+++ b/Assets/Scenes/SimulationScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.43040666, g: 0.46535593, b: 0.4972127, a: 1}
+  m_IndirectSpecularColor: {r: 0.43041572, g: 0.46536624, b: 0.4972176, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -973,7 +973,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 329256999}
   m_LocalRotation: {x: 0.5254717, y: 0, z: 0, w: 0.8508111}
-  m_LocalPosition: {x: 0, y: 30, z: -15}
+  m_LocalPosition: {x: 0, y: 38, z: -19}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 276180080}
@@ -2579,7 +2579,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1381831132}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 30, z: 0}
+  m_LocalPosition: {x: 0, y: 43, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 276180080}

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -43,6 +43,11 @@ namespace Dora {
             var t = transform; // Temp storage of build-in is (apparently) more efficient than repeated access.
             newPosition = t.position;
             newRotation = t.rotation;
+            CameraInitialization();
+        }
+
+        private void CameraInitialization() {
+
             _cams = new List<CamAssembly>();
             foreach (var c in GetComponentsInChildren<Camera>()) {
                 var ct = c.transform;
@@ -98,8 +103,14 @@ namespace Dora {
 
         private void ApplyMovement() {
             var t = transform;
+            
+            
             t.position = Vector3.Lerp(t.position, newPosition, Time.deltaTime * movementTime);
             t.rotation = Quaternion.Lerp(t.rotation, newRotation, Time.deltaTime * movementTime);
+            
+            if (_cams == null) { // On a code hot-reload in unity, _cams is set to null.
+                CameraInitialization();
+            }
             foreach (var c in _cams) {
                 var ct = c.camera.transform;
                 ct.localPosition =


### PR DESCRIPTION
Camera null reference exception after hot reload should no longer
appera.
Cameras have been positioned slightly differently, so switching
between angles should keep roughly the same zoom level.